### PR TITLE
Proper grammar, username is null when user is not authenticated.

### DIFF
--- a/src/me/StevenLawson/BukkitTelnet/session/ClientSession.java
+++ b/src/me/StevenLawson/BukkitTelnet/session/ClientSession.java
@@ -70,7 +70,7 @@ public final class ClientSession extends Thread
 
         if (!authenticate())
         {
-            writeLine("Authentication failed for " + username + ". Please verify on RubyFreedom before connecting to telnet.");
+            writeLine("Authentication failed. Please verify on RubyFreedom before connecting to telnet.");
             syncTerminateSession();
         }
 


### PR DESCRIPTION
Fix a bit of code, that doesn't work when the user is not authenticated, so it makes a grammar error. This is fixed with this pull request.